### PR TITLE
Added react icons of Show password to Signup and Signin page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.2",
         "react-hot-toast": "^2.4.1",
+        "react-icons": "^5.3.0",
         "react-infinite-scroll-component": "^6.1.0",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.26.0",
@@ -4407,6 +4408,14 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-infinite-scroll-component": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.2",
     "react-hot-toast": "^2.4.1",
+    "react-icons": "^5.3.0",
     "react-infinite-scroll-component": "^6.1.0",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.26.0",

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -18,9 +18,12 @@ import signinSchema from "@/lib/schemas/signin.schema";
 import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 import { BACKEND_URL } from "@/utils/constants";
+import { AiOutlineEyeInvisible,AiOutlineEye } from "react-icons/ai";
+
 
 const Signin = () => {
   const [submitting, setSubmiting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const router = useNavigate();
 
   const form = useForm<z.infer<typeof signinSchema>>({
@@ -91,11 +94,18 @@ const Signin = () => {
                 <FormItem>
                   <FormLabel>Password</FormLabel>
                   <FormControl>
-                    <Input
-                      type="password"
-                      placeholder="Enter a password"
-                      {...field}
-                    />
+                  <div className="relative">
+                      <Input
+                        type={showPassword ? "text" : "password"}
+                        placeholder="Enter a password"
+                        {...field}
+                      />
+                      <span 
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-2 top-[0.6rem] text-xl text-[#686868]">
+                        {showPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+                        </span>
+                      </div>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -18,9 +18,14 @@ import { useState } from "react";
 import { LoaderCircle } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { BACKEND_URL } from "@/utils/constants";
+import { AiOutlineEyeInvisible,AiOutlineEye } from "react-icons/ai";
+
 
 const Signup = () => {
   const [submiting, setSubmiting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
   const router = useNavigate();
 
   const form = useForm<z.infer<typeof signupSchema>>({
@@ -142,16 +147,24 @@ const Signup = () => {
                   <FormItem>
                     <FormLabel>Password</FormLabel>
                     <FormControl>
+                      <div className="relative">
                       <Input
-                        type="password"
+                        type={showPassword ? "text" : "password"}
                         placeholder="Enter a password"
                         {...field}
                       />
+                      <span 
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-2 top-[0.6rem] text-xl text-[#686868]">
+                        {showPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+                        </span>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
               <FormField
                 control={form.control}
                 name="confirmPassword"
@@ -159,11 +172,18 @@ const Signup = () => {
                   <FormItem>
                     <FormLabel>Confirm Password</FormLabel>
                     <FormControl>
+                    <div className="relative">
                       <Input
-                        type="password"
-                        placeholder="Enter the password again"
+                        type={showConfirmPassword ? "text" : "password"}
+                        placeholder="Enter a password"
                         {...field}
                       />
+                      <span 
+                        onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                        className="absolute right-2 top-[0.6rem] text-xl text-[#686868]">
+                        {showConfirmPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+                        </span>
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
**Steps I did:**
- Implemented a password visibility toggle for both the password and confirm password fields.
- Used react-icons for the eye icons (AiOutlineEye and AiOutlineEyeInvisible).
- Introduced the useState hook to manage a showPassword state variable that toggles the input type between "password" and "text".
- Added an onClick event on the eye icon to toggle the visibility.